### PR TITLE
Fixed problems with wrong detection of stack size for spiffs function…

### DIFF
--- a/module_spiffs/src/spiffs/spiffs_cache.c
+++ b/module_spiffs/src/spiffs/spiffs_cache.c
@@ -29,6 +29,8 @@ static spiffs_cache_page *spiffs_cache_page_get(spiffs *fs, spiffs_page_ix pix) 
   return 0;
 }
 
+
+#pragma stackfunction  200
 // frees cached page
 static s32_t spiffs_cache_page_free(spiffs *fs, int ix, u8_t write_back) {
   s32_t res = SPIFFS_OK;

--- a/module_spiffs/src/spiffs/spiffs_nucleus.c
+++ b/module_spiffs/src/spiffs/spiffs_nucleus.c
@@ -1159,6 +1159,7 @@ s32_t spiffs_object_open_by_page(
 }
 
 #if !SPIFFS_READ_ONLY
+#pragma stackfunction  200
 // Append to object
 // keep current object index (header) page in fs->work buffer
 s32_t spiffs_object_append(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {
@@ -1407,6 +1408,7 @@ s32_t spiffs_object_append(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {
 #endif // !SPIFFS_READ_ONLY
 
 #if !SPIFFS_READ_ONLY
+#pragma stackfunction  200
 // Modify object
 // keep current object index (header) page in fs->work buffer
 s32_t spiffs_object_modify(spiffs_fd *fd, u32_t offset, u8_t *data, u32_t len) {


### PR DESCRIPTION
Solved problems with wrong detection of stack size for spiffs functions (with different optimizations) 

Fixed problems with wrong detection of stack size for spiffs functions. With different optimizations we had errors in different functions.

We are getting an errors
Error: Meta information ("xxx.nstackwords") for function "xxx" cannot be determined. 
Error:   lower bound could not be calculated (function is recursive?)

Where "xxx" were different functions in spiffs