### PR TITLE
bugfix, config changes, new feature added

### DIFF
--- a/module_spiffs/src/spiffs/spiffs_config.h
+++ b/module_spiffs/src/spiffs/spiffs_config.h
@@ -58,7 +58,7 @@ typedef unsigned char u8_t;
 // Enables/disable memory read caching of nucleus file system operations.
 // If enabled, memory area must be provided for cache in SPIFFS_mount.
 #ifndef  SPIFFS_CACHE
-#define SPIFFS_CACHE                    1
+#define SPIFFS_CACHE                    0
 #endif
 #if SPIFFS_CACHE
 // Enables memory write caching for file descriptors in hydrogen
@@ -121,7 +121,7 @@ typedef unsigned char u8_t;
 // Lower value generates more read/writes. No meaning having it bigger
 // than logical page size.
 #ifndef SPIFFS_COPY_BUFFER_STACK
-#define SPIFFS_COPY_BUFFER_STACK        (256)
+#define SPIFFS_COPY_BUFFER_STACK        (64)
 #endif
 
 // Enable this to have an identifiable spiffs filesystem. This will look for
@@ -235,7 +235,7 @@ typedef unsigned char u8_t;
 // directly. If all available descriptors become opened, all cache memory is
 // lost.
 #ifndef SPIFFS_TEMPORAL_FD_CACHE
-#define SPIFFS_TEMPORAL_FD_CACHE              1
+#define SPIFFS_TEMPORAL_FD_CACHE              0
 #endif
 
 // Temporal file cache hit score. Each time a file is opened, all cached files
@@ -245,6 +245,7 @@ typedef unsigned char u8_t;
 // be between 1 (no gain for hitting a cached entry often) and 255.
 #ifndef SPIFFS_TEMPORAL_CACHE_HIT_SCORE
 #define SPIFFS_TEMPORAL_CACHE_HIT_SCORE       4
+
 #endif
 
 // Enable to be able to map object indices to memory.

--- a/module_spiffs/src/spiffs/spiffs_nucleus.c
+++ b/module_spiffs/src/spiffs/spiffs_nucleus.c
@@ -62,7 +62,7 @@ static s32_t spiffs_page_index_check(spiffs *fs, spiffs_fd *fd, spiffs_page_ix p
 #endif // !SPIFFS_READ_ONLY
 
 #if !SPIFFS_CACHE
-
+#pragma stackfunction  300
 s32_t spiffs_phys_rd(
     spiffs *fs,
     u32_t addr,
@@ -71,6 +71,7 @@ s32_t spiffs_phys_rd(
   return SPIFFS_HAL_READ(fs, addr, len, dst);
 }
 
+#pragma stackfunction  300
 s32_t spiffs_phys_wr(
     spiffs *fs,
     u32_t addr,
@@ -320,7 +321,7 @@ s32_t spiffs_probe(
 }
 #endif // SPIFFS_USE_MAGIC && SPIFFS_USE_MAGIC_LENGTH && SPIFFS_SINGLETON==0
 
-
+#pragma stackfunction  200
 static s32_t spiffs_obj_lu_scan_v(
     spiffs *fs,
     spiffs_obj_id obj_id,
@@ -349,6 +350,7 @@ static s32_t spiffs_obj_lu_scan_v(
 // Scans thru all obj lu and counts free, deleted and used pages
 // Find the maximum block erase count
 // Checks magic if enabled
+#pragma stackfunction  200
 s32_t spiffs_obj_lu_scan(
     spiffs *fs) {
   s32_t res;
@@ -813,6 +815,7 @@ s32_t spiffs_page_allocate_data(
 #if !SPIFFS_READ_ONLY
 // Moves a page from src to a free page and finalizes it. Updates page index. Page data is given in param page.
 // If page data is null, provided header is used for metainfo and page data is physically copied.
+#pragma stackfunction 200
 s32_t spiffs_page_move(
     spiffs *fs,
     spiffs_file fh,
@@ -877,6 +880,7 @@ s32_t spiffs_page_move(
 
 #if !SPIFFS_READ_ONLY
 // Deletes a page and removes it from object lookup.
+#pragma stackfunction 200
 s32_t spiffs_page_delete(
     spiffs *fs,
     spiffs_page_ix pix) {
@@ -967,6 +971,7 @@ s32_t spiffs_object_create(
 // new_objix_hdr_data may be null, if so the object index header page is loaded
 // name may be null, if so name is not changed
 // size may be null, if so size is not changed
+#pragma stackfunction 200
 s32_t spiffs_object_update_index_hdr(
     spiffs *fs,
     spiffs_fd *fd,
@@ -1121,6 +1126,7 @@ s32_t spiffs_object_open_by_id(
 }
 
 // Open object by page index
+#pragma stackfunction 200
 s32_t spiffs_object_open_by_page(
     spiffs *fs,
     spiffs_page_ix pix,
@@ -1918,7 +1924,7 @@ s32_t spiffs_object_truncate(
   return res;
 } // spiffs_object_truncate
 #endif // !SPIFFS_READ_ONLY
-
+#pragma stackfunction 200
 s32_t spiffs_object_read(
     spiffs_fd *fd,
     u32_t offset,

--- a/module_spiffs/src/spiffs_service.h
+++ b/module_spiffs/src/spiffs_service.h
@@ -20,7 +20,7 @@
 /**
  * @brief Maximum value of file descriptor
  */
-#define SPIFFS_MAX_FILE_DESCRIPTOR 256
+#define SPIFFS_MAX_FILE_DESCRIPTOR 4
 
 /**
  * @brief Maximum data buffer size
@@ -44,6 +44,7 @@
 #define SPIFFS_O_RDWR                   SPIFFS_RDWR
 
 #define SPIFFS_EOF                      -10003
+#define SPIFFS_ERR_NOT_FOUND            -10002
 #define SPIFFS_ERR_FULL                 -10001
 
 #define SPIFFS_SEEK_SET                 (0)
@@ -72,7 +73,7 @@ interface SPIFFSInterface {
      *                      SPIFFS_O_WRONLY, SPIFFS_O_RDWR, SPIFFS_O_DIRECT, SPIFFS_O_EXCL
      * @returns the filehandle
      */
-    [[guarded]] unsigned short open_file(char path[], unsigned path_length, unsigned short flags);
+    [[guarded]] short open_file(char path[], unsigned path_length, unsigned short flags);
 
     /**
      * @brief Closes a filehandle. If there are pending write operations, these are finalized before closing.
@@ -129,6 +130,12 @@ interface SPIFFSInterface {
      * @param name             Name of file
      */
     [[guarded]] int status(unsigned short fd, unsigned short &obj_id, unsigned int &size, unsigned char &type, unsigned short &pix, char name[]);
+
+
+    /**
+    * @brief Gets file size by filehandle
+    */
+    [[guarded]] int get_file_size(unsigned short fd);
 
     /**
      * @brief Renames a file

--- a/module_spiffs/src/spiffs_service.xc
+++ b/module_spiffs/src/spiffs_service.xc
@@ -61,14 +61,14 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
 
     while (1) {
         select {
-                   case !isnull(i_spiffs) => i_spiffs[int i].open_file(char path[], unsigned path_length, unsigned short flags) -> unsigned short fd:
+                   case !isnull(i_spiffs) => i_spiffs[int i].open_file(char path[], unsigned path_length, unsigned short flags) -> short fd:
                        char buffer[SPIFFS_MAX_FILENAME_SIZE];
                        memcpy(buffer,path,path_length+1);
-#pragma stackcalls 200
+
                        fd = iSPIFFS_open(buffer, flags);
                    break;
                    case !isnull(i_spiffs) => i_spiffs[int i].close_file(unsigned short fd) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_close(fd);
                    break;
 
@@ -79,7 +79,7 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
                        for (int il = len; il > 0; il = il - SPIFFS_MAX_DATA_BUFFER_SIZE)
                        {
                            read_len = (il > SPIFFS_MAX_DATA_BUFFER_SIZE ? SPIFFS_MAX_DATA_BUFFER_SIZE : il);
-#pragma stackcalls 200
+
                            res = iSPIFFS_read(fd, buffer, read_len);
                            if (res < 0) break; else res = len;
                            memcpy(data + read_offset, buffer, read_len);
@@ -95,7 +95,7 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
                        {
                            write_len = (il > SPIFFS_MAX_DATA_BUFFER_SIZE ? SPIFFS_MAX_DATA_BUFFER_SIZE : il);
                            memcpy(buffer, data + write_offset, write_len);
-#pragma stackcalls 200
+
                            res = iSPIFFS_write(fd, buffer, write_len);
                            if (res < 0) break; else res = len;
                            write_offset += write_len;
@@ -103,29 +103,34 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].remove_file(unsigned short fd) -> int res:
-#pragma stackcalls 200
+
                         res = iSPIFFS_remove(fd);
                    break;
 
+                   case !isnull(i_spiffs) => i_spiffs[int i].get_file_size(unsigned short fd) -> int res:
+
+                        res = iSPIFFS_get_size(fd);
+                   break;
+
                    case !isnull(i_spiffs) => i_spiffs[int i].vis() -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_vis();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].ls() -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_ls();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].check() -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_check();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].status(unsigned short fd, unsigned short &obj_id, unsigned int &size, unsigned char &type, unsigned short &pix, char name[]) -> int res:
                            unsigned stat_buffer[sizeof(spiffs_stat)];
                            spiffs_stat s;
-#pragma stackcalls 200
+
                            res = iSPIFFS_status(fd, stat_buffer);
                            memcpy(&s, stat_buffer, sizeof(spiffs_stat));
                            obj_id = s.obj_id;
@@ -136,22 +141,22 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].unmount():
-#pragma stackcalls 200
+
                        iSPIFFS_unmount();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].format() -> int res:
-#pragma stackcalls 200
+
                         res = iSPIFFS_format();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].tell(unsigned short fd) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_tell(fd);
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].seek(unsigned short fd, int offs, int whence) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_seek(fd, offs, whence);
                    break;
 
@@ -160,36 +165,36 @@ void spiffs_service(CLIENT_INTERFACE(FlashDataInterface, i_data), interface SPIF
                        char new_buffer[SPIFFS_MAX_FILENAME_SIZE];
                        memcpy(old_buffer,old_path,old_path_length+1);
                        memcpy(new_buffer,new_path,new_path_length+1);
-#pragma stackcalls 200
+
                        res = iSPIFFS_rename(old_buffer, new_buffer);
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].flush(unsigned short fd) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_flush(fd);
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].errno() -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_errno();
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].fs_info(unsigned int &total, unsigned int &used) -> int res:
                           unsigned int buffer_total[1];
                           unsigned int buffer_used[1];
-#pragma stackcalls 200
+
                           res = iSPIFFS_info(buffer_total, buffer_used);
                           total = buffer_total[0];
                           used = buffer_used[0];
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].gc(unsigned int size) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_gc(size);
                    break;
 
                    case !isnull(i_spiffs) => i_spiffs[int i].gc_quick(unsigned short max_free_pages) -> int res:
-#pragma stackcalls 200
+
                        res = iSPIFFS_gc_quick(max_free_pages);
                    break;
 

--- a/module_spiffs/src/spiffs_xc_wrapper.c
+++ b/module_spiffs/src/spiffs_xc_wrapper.c
@@ -74,7 +74,7 @@ void spiffs_init(CLIENT_INTERFACE(FlashDataInterface, i_data))
 }
 
 
-unsigned short iSPIFFS_open(char path[], unsigned short flags)
+short iSPIFFS_open(char path[], unsigned short flags)
 {
     unsigned short fd = SPIFFS_open(&fs, path,  flags, 0);
     return fd;
@@ -168,6 +168,16 @@ int iSPIFFS_status(unsigned short fd, unsigned stat[])
     int res;
     res = SPIFFS_fstat(&fs, fd, (spiffs_stat *)stat);
     return res;
+}
+
+int iSPIFFS_get_size(unsigned short fd)
+{
+    int res;
+    spiffs_stat s;
+    res = SPIFFS_fstat(&fs, fd, &s);
+    if (res < 0) return res;
+    else
+      return s.size;
 }
 
 int iSPIFFS_flush(unsigned short fd)

--- a/module_spiffs/src/spiffs_xc_wrapper.h
+++ b/module_spiffs/src/spiffs_xc_wrapper.h
@@ -21,7 +21,7 @@ extern "C" {
 
 void spiffs_init(CLIENT_INTERFACE(FlashDataInterface, i_data));
 
-unsigned short iSPIFFS_open(char path[], unsigned short flags);
+short iSPIFFS_open(char path[], unsigned short flags);
 int iSPIFFS_close(unsigned short fd);
 int iSPIFFS_read(unsigned short fd, unsigned char data[], unsigned int len);
 int iSPIFFS_write(unsigned short fd, unsigned char data[], unsigned int len);
@@ -30,6 +30,7 @@ int iSPIFFS_vis(void);
 int iSPIFFS_ls(void);
 int iSPIFFS_check(void);
 int iSPIFFS_status(unsigned short fd, unsigned stat[]);
+int iSPIFFS_get_size(unsigned short fd);
 int iSPIFFS_rename(char old[], char newPath[]);
 int iSPIFFS_format(void);
 int iSPIFFS_seek(unsigned short fd, int offs, int whence);


### PR DESCRIPTION
Configuration:
-disabled cache to reduce RAM usage (with cache we can open just 2 files in one time, without - 4) 
-reduced copy buffer stack 
-disabled temporal fd chache 
Added feature:
-added function get_file_size()
Bugfix:
-fixed compilation issue by SPIFFS_CACHE 0
-removed unnecessary #pragma stackcalls 200 from spiffs_service.xc
-changed return value type for open_file() from unsigned to signed for correct errors returning