### PR TITLE
Feature rtc update sqwe register bit

### DIFF
--- a/examples/app_test_rtc/src/main.xc
+++ b/examples/app_test_rtc/src/main.xc
@@ -30,6 +30,8 @@ void RTC_run_test(client interface rtc_communication rtc)
     rtc.set_Month(1);                 /* (01-12) */
     rtc.set_Century(21);              /* (21-23) */
     rtc.set_Year(17);                /* (00-99) */
+    rtc.set_SQWE(1);                /* (0-1)  */
+    rtc.set_SQW_Freq(RTC_SQW_FREQ_4KHZ);
 
     while (1)
     {
@@ -65,7 +67,19 @@ void RTC_run_test(client interface rtc_communication rtc)
         data = rtc.get_Year(result);
         printf("%d\n", data);
 
+        // read SQWE bit
+        data = rtc.get_SQWE(result);
+        printf("SQWE bit = %d\n", data);
+
+        // read Square Wave Frequency
+        data = rtc.get_SQW_Freq(result);
+        printf("RTC square wave frequency = %d\n", data);
+
+        // read Day of week
+        data = rtc.get_Day_of_week(result);
+        printf("Day of Week = %d\n", data);
         delay_seconds(5);
+
     }
 
 }

--- a/module_rtc/.cproject
+++ b/module_rtc/.cproject
@@ -18,12 +18,12 @@
 							<targetPlatform archList="all" binaryParser="com.xmos.cdt.core.XEBinaryParser;org.eclipse.cdt.core.GNU_ELF" id="com.xmos.cdt.core.platform.1151909796" isAbstract="false" osList="linux,win32,macosx" superClass="com.xmos.cdt.core.platform"/>
 							<builder id="com.xmos.cdt.builder.base.869797880" keepEnvironmentInBuildfile="false" managedBuildOn="false" superClass="com.xmos.cdt.builder.base"/>
 							<tool id="com.xmos.cdt.xc.compiler.276633128" name="com.xmos.cdt.xc.compiler" superClass="com.xmos.cdt.xc.compiler">
-								<option id="com.xmos.xc.compiler.option.include.paths.1124689399" superClass="com.xmos.xc.compiler.option.include.paths" valueType="includePath">
+								<option id="com.xmos.xc.compiler.option.include.paths.1124689399" name="com.xmos.xc.compiler.option.include.paths" superClass="com.xmos.xc.compiler.option.include.paths" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include/xc&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include/clang&quot;"/>
 								</option>
-								<option id="com.xmos.xc.compiler.option.defined.symbols.935131567" superClass="com.xmos.xc.compiler.option.defined.symbols" valueType="definedSymbols">
+								<option id="com.xmos.xc.compiler.option.defined.symbols.935131567" name="com.xmos.xc.compiler.option.defined.symbols" superClass="com.xmos.xc.compiler.option.defined.symbols" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__XC__=1"/>
 									<listOptionValue builtIn="false" value="__llvm__=1"/>
 									<listOptionValue builtIn="false" value="__ATOMIC_RELAXED=0"/>
@@ -175,11 +175,11 @@
 								<inputType id="com.xmos.cdt.xc.compiler.input.1889569723" name="XC" superClass="com.xmos.cdt.xc.compiler.input"/>
 							</tool>
 							<tool id="com.xmos.cdt.c.compiler.1988670423" name="com.xmos.cdt.c.compiler" superClass="com.xmos.cdt.c.compiler">
-								<option id="com.xmos.c.compiler.option.include.paths.1034881299" superClass="com.xmos.c.compiler.option.include.paths" valueType="includePath">
+								<option id="com.xmos.c.compiler.option.include.paths.1034881299" name="com.xmos.c.compiler.option.include.paths" superClass="com.xmos.c.compiler.option.include.paths" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include/clang&quot;"/>
 								</option>
-								<option id="com.xmos.c.compiler.option.defined.symbols.767969455" superClass="com.xmos.c.compiler.option.defined.symbols" valueType="definedSymbols">
+								<option id="com.xmos.c.compiler.option.defined.symbols.767969455" name="com.xmos.c.compiler.option.defined.symbols" superClass="com.xmos.c.compiler.option.defined.symbols" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__llvm__=1"/>
 									<listOptionValue builtIn="false" value="__clang__=1"/>
 									<listOptionValue builtIn="false" value="__clang_major__=3"/>
@@ -478,12 +478,12 @@
 								<inputType id="com.xmos.cdt.c.compiler.input.c.1432561209" name="C" superClass="com.xmos.cdt.c.compiler.input.c"/>
 							</tool>
 							<tool id="com.xmos.cdt.cxx.compiler.1080903331" name="com.xmos.cdt.cxx.compiler" superClass="com.xmos.cdt.cxx.compiler">
-								<option id="com.xmos.cxx.compiler.option.include.paths.1247089484" superClass="com.xmos.cxx.compiler.option.include.paths" valueType="includePath">
+								<option id="com.xmos.cxx.compiler.option.include.paths.1247089484" name="com.xmos.cxx.compiler.option.include.paths" superClass="com.xmos.cxx.compiler.option.include.paths" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include/clang&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XMOS_TOOL_PATH}/target/include/c++/v1&quot;"/>
 								</option>
-								<option id="com.xmos.cxx.compiler.option.defined.symbols.1278594985" superClass="com.xmos.cxx.compiler.option.defined.symbols" valueType="definedSymbols">
+								<option id="com.xmos.cxx.compiler.option.defined.symbols.1278594985" name="com.xmos.cxx.compiler.option.defined.symbols" superClass="com.xmos.cxx.compiler.option.defined.symbols" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__llvm__=1"/>
 									<listOptionValue builtIn="false" value="__clang__=1"/>
 									<listOptionValue builtIn="false" value="__clang_major__=3"/>

--- a/module_rtc/doc/index.rst
+++ b/module_rtc/doc/index.rst
@@ -125,6 +125,11 @@ How to use
 API
 ===
 
+Types
+-----
+
+.. doxygenenum:: RTC_SQW_FREQ
+
 Service
 --------
 

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -121,6 +121,14 @@ interface rtc_communication {
     void    set_Century(uint8_t data);
 
     /**
+     * @brief Setter for SQWE bit.
+     *
+     * @param data SQWE bit value (0 or 1).
+     */
+
+    void    set_SQWE(uint8_t data);
+
+    /**
      * @brief Getter for Hours.
      *
      * @param resultat i2c_regop_res_t structure from i2c library to report back on whether the read/write operation of the i2c was a success or not.
@@ -209,6 +217,17 @@ interface rtc_communication {
      */
 
     unsigned get_Century(i2c_regop_res_t result);
+
+
+    /**
+     * @brief Getter for SQWE bit.
+     *
+     * @param resultat i2c_regop_res_t structure from i2c library to report back on whether the read/write operation of the i2c was a success or not.
+     *
+     * @return value of SQWE bit.
+     */
+
+    unsigned get_SQWE(i2c_regop_res_t result);
 };
 
 /**

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -153,7 +153,7 @@ interface rtc_communication {
     /**
      * @brief Setter for Square Wave output frequency.
      *
-     * @param data integer value corresponding to frequency (1 to 15).
+     * @param data variable of type RTC_SQW_FREQ.
      */
 
     void    set_SQW_Freq(RTC_SQW_FREQ data);
@@ -261,11 +261,11 @@ interface rtc_communication {
     unsigned get_SQWE(i2c_regop_res_t result);
 
     /**
-     * @brief Getter for integer value corresponding to square wave frequency.
+     * @brief Getter for square wave frequency value.
      *
      * @param resultat i2c_regop_res_t structure from i2c library to report back on whether the read/write operation of the i2c was a success or not.
      *
-     * @return value integer value corresponding to square wave frequency.
+     * @return value of type RTC_SQW_FREQ.
      */
 
     RTC_SQW_FREQ get_SQW_Freq(i2c_regop_res_t result);

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -129,6 +129,15 @@ interface rtc_communication {
     void    set_SQWE(uint8_t data);
 
     /**
+     * @brief Setter for Square Wave output frequency.
+     *
+     * @param data integer value corresponding to frequency (1 to 15).
+     */
+
+    void    set_square_wave_frequency(uint8_t data);
+
+
+    /**
      * @brief Getter for Hours.
      *
      * @param resultat i2c_regop_res_t structure from i2c library to report back on whether the read/write operation of the i2c was a success or not.
@@ -228,6 +237,16 @@ interface rtc_communication {
      */
 
     unsigned get_SQWE(i2c_regop_res_t result);
+
+    /**
+     * @brief Getter for integer value corresponding to square wave frequency.
+     *
+     * @param resultat i2c_regop_res_t structure from i2c library to report back on whether the read/write operation of the i2c was a success or not.
+     *
+     * @return value integer value corresponding to square wave frequency.
+     */
+
+    unsigned get_square_wave_frequency(i2c_regop_res_t result);
 };
 
 /**

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -156,7 +156,7 @@ interface rtc_communication {
      * @param data integer value corresponding to frequency (1 to 15).
      */
 
-    void    set_square_wave_frequency(RTC_SQW_FREQ data);
+    void    set_SQW_Freq(RTC_SQW_FREQ data);
 
 
     /**
@@ -268,7 +268,7 @@ interface rtc_communication {
      * @return value integer value corresponding to square wave frequency.
      */
 
-    RTC_SQW_FREQ get_square_wave_frequency(i2c_regop_res_t result);
+    RTC_SQW_FREQ get_SQW_Freq(i2c_regop_res_t result);
 };
 
 /**

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -24,6 +24,27 @@
 #define Flags                   0xF
 #define Addr_Slave              0x68  // (1101000)
 
+/**
+ * @brief RTC Square Wave Frequency types
+ */
+typedef enum
+{
+    RTC_SQW_FREQ_32KHZ = 0x10,          /**< RTC Square Wave Frequency 32 KHZ */
+    RTC_SQW_FREQ_8KHZ = 0x20,           /**< RTC Square Wave Frequency 8 KHZ */
+    RTC_SQW_FREQ_4KHZ = 0x30,           /**< RTC Square Wave Frequency 4 KHZ */
+    RTC_SQW_FREQ_2KHZ = 0x40,           /**< RTC Square Wave Frequency 2 KHZ */
+    RTC_SQW_FREQ_1KHZ = 0x50,           /**< RTC Square Wave Frequency 1 KHZ */
+    RTC_SQW_FREQ_512HZ = 0x60,          /**< RTC Square Wave Frequency 512 HZ */
+    RTC_SQW_FREQ_256HZ = 0x70,          /**< RTC Square Wave Frequency 256 HZ */
+    RTC_SQW_FREQ_128HZ = 0x80,          /**< RTC Square Wave Frequency 128 HZ */
+    RTC_SQW_FREQ_64HZ = 0x90,           /**< RTC Square Wave Frequency 64 HZ */
+    RTC_SQW_FREQ_32HZ = 0xA0,           /**< RTC Square Wave Frequency 32 HZ */
+    RTC_SQW_FREQ_16HZ = 0xB0,           /**< RTC Square Wave Frequency 16 HZ */
+    RTC_SQW_FREQ_8HZ = 0xC0,            /**< RTC Square Wave Frequency 8 HZ */
+    RTC_SQW_FREQ_4HZ = 0xD0,            /**< RTC Square Wave Frequency 4 HZ */
+    RTC_SQW_FREQ_2HZ = 0xE0,            /**< RTC Square Wave Frequency 2 HZ */
+    RTC_SQW_FREQ_1HZ = 0xF0             /**< RTC Square Wave Frequency 1 HZ */
+} RTC_SQW_FREQ;
 
 /**
  * @brief Configuration structure of the I2C ports.
@@ -134,7 +155,7 @@ interface rtc_communication {
      * @param data integer value corresponding to frequency (1 to 15).
      */
 
-    void    set_square_wave_frequency(uint8_t data);
+    void    set_square_wave_frequency(RTC_SQW_FREQ data);
 
 
     /**
@@ -246,7 +267,7 @@ interface rtc_communication {
      * @return value integer value corresponding to square wave frequency.
      */
 
-    unsigned get_square_wave_frequency(i2c_regop_res_t result);
+    RTC_SQW_FREQ get_square_wave_frequency(i2c_regop_res_t result);
 };
 
 /**

--- a/module_rtc/src/rtc_config.h
+++ b/module_rtc/src/rtc_config.h
@@ -29,6 +29,7 @@
  */
 typedef enum
 {
+    RTC_SQW_FREQ_NONE = 0x00,           /**< RTC Square Wave Frequency None */
     RTC_SQW_FREQ_32KHZ = 0x10,          /**< RTC Square Wave Frequency 32 KHZ */
     RTC_SQW_FREQ_8KHZ = 0x20,           /**< RTC Square Wave Frequency 8 KHZ */
     RTC_SQW_FREQ_4KHZ = 0x30,           /**< RTC Square Wave Frequency 4 KHZ */

--- a/module_rtc/src/rtc_service.xc
+++ b/module_rtc/src/rtc_service.xc
@@ -101,7 +101,12 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                     RTC_write(i2c, Addr_Slave, Century_Month, data);
                 break;
            case rtc.set_Day_of_week(uint8_t data):
-                     RTC_write(i2c, Addr_Slave, Day, data);
+                     i2c_regop_res_t result;
+                     uint8_t day;
+                     day = RTC_read(i2c, Addr_Slave, Day, result);
+                     day = day & 0xf8;
+                     day = day | (data & 0x07);
+                     RTC_write(i2c, Addr_Slave, Day, day);
                  break;
            case rtc.set_Date(uint8_t data):
                      tens = data / 10;
@@ -118,6 +123,14 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                      sqwe = sqwe | (data<<6);
                      RTC_write(i2c, Addr_Slave, Al_month, sqwe);
                  break;
+           case rtc.set_square_wave_frequency(uint8_t data):
+                     i2c_regop_res_t result;
+                     uint8_t day;
+                     day = RTC_read(i2c, Addr_Slave, Day, result);
+                     day = day & 0x0f;
+                     day = day | (data << 4);
+                     RTC_write(i2c, Addr_Slave, Day, day);
+                     break;
            case rtc.get_Hours(i2c_regop_res_t result) -> unsigned data_actual:
                    // read Hours
                    data = RTC_read(i2c, Addr_Slave, Hours, result);
@@ -180,6 +193,10 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
            case rtc.get_SQWE(i2c_regop_res_t result) -> unsigned data_actual:
                    data = RTC_read(i2c, Addr_Slave, Al_month, result);
                    data_actual = (data >> 6) & 0xF;
+                 break;
+           case rtc.get_square_wave_frequency(i2c_regop_res_t result) -> unsigned data_actual:
+                   data = RTC_read(i2c, Addr_Slave, Day, result);
+                   data_actual = (data >> 4) & 0x0F;
                  break;
            default : break;
                     }

--- a/module_rtc/src/rtc_service.xc
+++ b/module_rtc/src/rtc_service.xc
@@ -123,12 +123,12 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                      sqwe = sqwe | (data<<6);
                      RTC_write(i2c, Addr_Slave, Al_month, sqwe);
                  break;
-           case rtc.set_square_wave_frequency(uint8_t data):
+           case rtc.set_square_wave_frequency(RTC_SQW_FREQ data):
                      i2c_regop_res_t result;
                      uint8_t day;
                      day = RTC_read(i2c, Addr_Slave, Day, result);
-                     day = day & 0x0f;
-                     day = day | (data << 4);
+                     day = day & 0x0F;
+                     day = day | data;
                      RTC_write(i2c, Addr_Slave, Day, day);
                      break;
            case rtc.get_Hours(i2c_regop_res_t result) -> unsigned data_actual:
@@ -194,7 +194,7 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                    data = RTC_read(i2c, Addr_Slave, Al_month, result);
                    data_actual = (data >> 6) & 0xF;
                  break;
-           case rtc.get_square_wave_frequency(i2c_regop_res_t result) -> unsigned data_actual:
+           case rtc.get_square_wave_frequency(i2c_regop_res_t result) -> RTC_SQW_FREQ data_actual:
                    data = RTC_read(i2c, Addr_Slave, Day, result);
                    data_actual = (data >> 4) & 0x0F;
                  break;

--- a/module_rtc/src/rtc_service.xc
+++ b/module_rtc/src/rtc_service.xc
@@ -125,24 +125,26 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                    RTC_write(i2c, Addr_Slave, Al_month, sqwe);
                  break;
            case rtc.set_SQW_Freq(RTC_SQW_FREQ data):
-                     i2c_regop_res_t result;
-                     uint8_t tmp;
+                   i2c_regop_res_t result;
+                   uint8_t tmp;
 
-                     if(data != RTC_SQW_FREQ_NONE)
-                     {
-                         tmp = RTC_read(i2c, Addr_Slave, Day, result);
-                         tmp = tmp & 0x0F;
-                         tmp = tmp | data;
-                         RTC_write(i2c, Addr_Slave, Day, tmp);
-                     }else{
-                         tmp = RTC_read(i2c, Addr_Slave, Day, result);
-                         tmp = tmp & 0x0F;
-                         RTC_write(i2c, Addr_Slave, Day, tmp);
-                         tmp = RTC_read(i2c, Addr_Slave, Al_month, result);
-                         tmp = tmp & 0xbf;
-                         RTC_write(i2c, Addr_Slave, Al_month, tmp);
-                     }
-                     break;
+                   if(data != RTC_SQW_FREQ_NONE)
+                   {
+                       tmp = RTC_read(i2c, Addr_Slave, Day, result);
+                       tmp = tmp & 0x0F;
+                       tmp = tmp | data;
+                       RTC_write(i2c, Addr_Slave, Day, tmp);
+                   }
+                   else
+                   {
+                       tmp = RTC_read(i2c, Addr_Slave, Day, result);
+                       tmp = tmp & 0x0F;
+                       RTC_write(i2c, Addr_Slave, Day, tmp);
+                       tmp = RTC_read(i2c, Addr_Slave, Al_month, result);
+                       tmp = tmp & 0xbf;
+                       RTC_write(i2c, Addr_Slave, Al_month, tmp);
+                   }
+                 break;
            case rtc.get_Hours(i2c_regop_res_t result) -> unsigned data_actual:
                    // read Hours
                    data = RTC_read(i2c, Addr_Slave, Hours, result);

--- a/module_rtc/src/rtc_service.xc
+++ b/module_rtc/src/rtc_service.xc
@@ -109,6 +109,15 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                      data = (tens << 4) | units;
                      RTC_write(i2c, Addr_Slave, Date, data);
                  break;
+           case rtc.set_SQWE(uint8_t data):
+                     i2c_regop_res_t result;
+                     uint8_t sqwe;
+                     /* Write enable bit to reg A */
+                     sqwe = RTC_read(i2c, Addr_Slave, Al_month, result);
+                     sqwe = sqwe & 0xbf;
+                     sqwe = sqwe | (data<<6);
+                     RTC_write(i2c, Addr_Slave, Al_month, sqwe);
+                 break;
            case rtc.get_Hours(i2c_regop_res_t result) -> unsigned data_actual:
                    // read Hours
                    data = RTC_read(i2c, Addr_Slave, Hours, result);
@@ -167,6 +176,10 @@ void rtc_service(server interface rtc_communication rtc, client interface i2c_ma
                    units = (data & 0xF);
                    tens = (data >> 4 ) & 0xF;
                    data_actual = (tens * 10) + units;
+                 break;
+           case rtc.get_SQWE(i2c_regop_res_t result) -> unsigned data_actual:
+                   data = RTC_read(i2c, Addr_Slave, Al_month, result);
+                   data_actual = (data >> 6) & 0xF;
                  break;
            default : break;
                     }


### PR DESCRIPTION
New interface functions are added to update SQWE bit in RTC to enable or disable the Square Wave output.
New interface functions are added to configure the frequency of square wave output of RTC. 
Update test application.
Update documentation.