### PR TITLE
Fix define inside BSP file for new naming scheme

### DIFF
--- a/module_board-support/bsp/CoreC2X/CoreC2X.bsp
+++ b/module_board-support/bsp/CoreC2X/CoreC2X.bsp
@@ -1,5 +1,5 @@
 /*****************
- * Core-C21-DX-G2
+ * Core-C2X
  * Rev. A
  *****************/
 
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <xscope.h>
 
-#define CORE_C21_DX_G2
+#define CORE_C2X
 
 /* Standard Tile definitions for demo/test apps */
 #define IF1_TILE	0


### PR DESCRIPTION
Fixed the define inside of the C2X BSP file.