### PR TITLE
Update App Makefiles to set C2X as default and show a list of old Core modules

### DIFF
--- a/examples/app_test_com-detect/Makefile
+++ b/examples/app_test_com-detect/Makefile
@@ -3,9 +3,11 @@
 # or a valid argument for the --target option when compiling
 
 # Possible SOMANET targets:
-# SOMANET-C22
-# SOMANET-C21-DX
-TARGET =
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to

--- a/examples/app_test_eeprom/Makefile
+++ b/examples/app_test_eeprom/Makefile
@@ -1,9 +1,13 @@
 # The TARGET variable determines what target system the application is
 # compiled for. It either refers to an XN file in the source directories
 # or a valid argument for the --target option when compiling
-# Possible Target
-# TARGET = SOMANET-C21-DX_G2
-TARGET = 
+
+# Possible SOMANET targets:
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to

--- a/examples/app_test_rtc/Makefile
+++ b/examples/app_test_rtc/Makefile
@@ -1,9 +1,13 @@
 # The TARGET variable determines what target system the application is
 # compiled for. It either refers to an XN file in the source directories
 # or a valid argument for the --target option when compiling
-#TARGET = SOMANET-CoreC2X
-TARGET = 
 
+# Possible SOMANET targets:
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to

--- a/examples/app_test_spiffs_console/Makefile
+++ b/examples/app_test_spiffs_console/Makefile
@@ -1,10 +1,13 @@
 # The TARGET variable determines what target system the application is
 # compiled for. It either refers to an XN file in the source directories
 # or a valid argument for the --target option when compiling
-#Possible SOMANET targets:
-# SOMANET-C22
-# SOMANET-C21-DX_G2
-TARGET =
+
+# Possible SOMANET targets:
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to
@@ -19,7 +22,7 @@ USED_MODULES = module_flash_service module_spiffs module_board-support
 # XCC_XC_FLAGS, XCC_C_FLAGS, XCC_ASM_FLAGS, XCC_CPP_FLAGS
 # If the variable XCC_MAP_FLAGS is set it overrides the flags passed to
 # xcc for the final link (mapping) stage.
-ifeq ($(TARGET),SOMANET-C22)
+ifeq ($(TARGET),SOMANET-CoreC22)
 XCC_FLAGS = -Os -g  -lflash
 else
 XCC_FLAGS = -Os -g  -lquadflash -DXCORE200=1

--- a/examples/app_test_temperature_sensor/Makefile
+++ b/examples/app_test_temperature_sensor/Makefile
@@ -1,9 +1,13 @@
 # The TARGET variable determines what target system the application is
 # compiled for. It either refers to an XN file in the source directories
 # or a valid argument for the --target option when compiling
-# Possible Targets
-# TARGET = SOMANET-C21-DX_G2
-TARGET = 
+
+# Possible SOMANET targets:
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to

--- a/examples/app_test_xscope/Makefile
+++ b/examples/app_test_xscope/Makefile
@@ -3,9 +3,11 @@
 # or a valid argument for the --target option when compiling.
 
 # Possible SOMANET targets:
-# SOMANET-C22
-# SOMANET-C21-DX
-TARGET =
+# SOMANET-CoreC22
+# SOMANET-CoreC21
+# SOMANET-CoreC21-rev-b
+# SOMANET-CoreC2X
+TARGET = SOMANET-CoreC2X
 
 # The APP_NAME variable determines the name of the final .xe file. It should
 # not include the .xe postfix. If left blank the name will default to


### PR DESCRIPTION
```
# Possible SOMANET targets: 
# SOMANET-CoreC22 
# SOMANET-CoreC21 
# SOMANET-CoreC21-rev-b 
# SOMANET-CoreC2X 
TARGET = SOMANET-CoreC2X
```

Fix name SOMANET-C22 -> SOMANET-CoreC22 for conditionall Makefile flags