### PR TITLE
Minor fixes in RTC

### DIFF
--- a/examples/app_test_rtc/src/main.xc
+++ b/examples/app_test_rtc/src/main.xc
@@ -27,10 +27,10 @@ void RTC_run_test(client interface i2c_master_if i2c)
     rtc_set_Hours(i2c, 11);               /* (00-23) */
     rtc_set_Day_of_week(i2c, 2);          /* (01-7) */
     rtc_set_Date(i2c, 30);                /* (01-31) */
-    rtc_set_Month(1);                 /* (01-12) */
-    rtc_set_Century(i2c, 21);              /* (21-23) */
+    rtc_set_Month(1);                     /* (01-12) */
+    rtc_set_Century(i2c, 21);             /* (20-23) */
     rtc_set_Year(i2c, 17);                /* (00-99) */
-    rtc_set_SQWE(i2c, 1);                /* (0-1)  */
+    rtc_set_SQWE(i2c, 1);                 /* (0-1)  */
     rtc_set_SQW_Freq(i2c, RTC_SQW_FREQ_4KHZ);
 
     while (1)

--- a/module_rtc/src/rtc.h
+++ b/module_rtc/src/rtc.h
@@ -29,22 +29,22 @@
  */
 typedef enum
 {
-    RTC_SQW_FREQ_NONE = 0x00,           /**< RTC Square Wave Frequency None */
-    RTC_SQW_FREQ_32KHZ = 0x10,          /**< RTC Square Wave Frequency 32 KHZ */
-    RTC_SQW_FREQ_8KHZ = 0x20,           /**< RTC Square Wave Frequency 8 KHZ */
-    RTC_SQW_FREQ_4KHZ = 0x30,           /**< RTC Square Wave Frequency 4 KHZ */
-    RTC_SQW_FREQ_2KHZ = 0x40,           /**< RTC Square Wave Frequency 2 KHZ */
-    RTC_SQW_FREQ_1KHZ = 0x50,           /**< RTC Square Wave Frequency 1 KHZ */
-    RTC_SQW_FREQ_512HZ = 0x60,          /**< RTC Square Wave Frequency 512 HZ */
-    RTC_SQW_FREQ_256HZ = 0x70,          /**< RTC Square Wave Frequency 256 HZ */
-    RTC_SQW_FREQ_128HZ = 0x80,          /**< RTC Square Wave Frequency 128 HZ */
-    RTC_SQW_FREQ_64HZ = 0x90,           /**< RTC Square Wave Frequency 64 HZ */
-    RTC_SQW_FREQ_32HZ = 0xA0,           /**< RTC Square Wave Frequency 32 HZ */
-    RTC_SQW_FREQ_16HZ = 0xB0,           /**< RTC Square Wave Frequency 16 HZ */
-    RTC_SQW_FREQ_8HZ = 0xC0,            /**< RTC Square Wave Frequency 8 HZ */
-    RTC_SQW_FREQ_4HZ = 0xD0,            /**< RTC Square Wave Frequency 4 HZ */
-    RTC_SQW_FREQ_2HZ = 0xE0,            /**< RTC Square Wave Frequency 2 HZ */
-    RTC_SQW_FREQ_1HZ = 0xF0             /**< RTC Square Wave Frequency 1 HZ */
+    RTC_SQW_FREQ_NONE = 0x0,           /**< RTC Square Wave Frequency None */
+    RTC_SQW_FREQ_32KHZ = 0x1,          /**< RTC Square Wave Frequency 32 KHZ */
+    RTC_SQW_FREQ_8KHZ = 0x2,           /**< RTC Square Wave Frequency 8 KHZ */
+    RTC_SQW_FREQ_4KHZ = 0x3,           /**< RTC Square Wave Frequency 4 KHZ */
+    RTC_SQW_FREQ_2KHZ = 0x4,           /**< RTC Square Wave Frequency 2 KHZ */
+    RTC_SQW_FREQ_1KHZ = 0x5,           /**< RTC Square Wave Frequency 1 KHZ */
+    RTC_SQW_FREQ_512HZ = 0x6,          /**< RTC Square Wave Frequency 512 HZ */
+    RTC_SQW_FREQ_256HZ = 0x7,          /**< RTC Square Wave Frequency 256 HZ */
+    RTC_SQW_FREQ_128HZ = 0x8,          /**< RTC Square Wave Frequency 128 HZ */
+    RTC_SQW_FREQ_64HZ = 0x9,           /**< RTC Square Wave Frequency 64 HZ */
+    RTC_SQW_FREQ_32HZ = 0xA,           /**< RTC Square Wave Frequency 32 HZ */
+    RTC_SQW_FREQ_16HZ = 0xB,           /**< RTC Square Wave Frequency 16 HZ */
+    RTC_SQW_FREQ_8HZ = 0xC,            /**< RTC Square Wave Frequency 8 HZ */
+    RTC_SQW_FREQ_4HZ = 0xD,            /**< RTC Square Wave Frequency 4 HZ */
+    RTC_SQW_FREQ_2HZ = 0xE,            /**< RTC Square Wave Frequency 2 HZ */
+    RTC_SQW_FREQ_1HZ = 0xF             /**< RTC Square Wave Frequency 1 HZ */
 } RTC_SQW_FREQ;
 
 /**

--- a/module_rtc/src/rtc.xc
+++ b/module_rtc/src/rtc.xc
@@ -12,16 +12,15 @@ uint8_t data_month = 1;
 
 uint8_t RTC_read(client interface i2c_master_if i2c, uint8_t device_addr, uint8_t reg, i2c_regop_res_t &result)
 {
-      uint8_t data = 0;
+    uint8_t data = 0;
 
-      data = i2c.read_reg(device_addr, reg, result);
-      if (result != I2C_REGOP_SUCCESS) {
-          printf("rtc read reg failed\n");
-          return -1;
-                                        }
-      else {
-            return data;
-            }
+    data = i2c.read_reg(device_addr, reg, result);
+    if (result != I2C_REGOP_SUCCESS) {
+        printf("rtc read reg failed\n");
+        return -1;
+    } else {
+        return data;
+    }
 }
 
 void RTC_write(client interface i2c_master_if i2c, uint8_t device_addr, uint8_t reg, uint8_t data)
@@ -158,7 +157,7 @@ void rtc_set_SQW_Freq(client interface i2c_master_if i2c, RTC_SQW_FREQ data)
     {
         tmp = RTC_read(i2c, Addr_Slave, Day, result);
         tmp = tmp & 0x0F;
-        tmp = tmp | data;
+        tmp = tmp | (data << 4);
         RTC_write(i2c, Addr_Slave, Day, tmp);
     }
     else
@@ -246,7 +245,7 @@ unsigned rtc_get_Century(client interface i2c_master_if i2c, i2c_regop_res_t res
     uint8_t data = 0;
     // read Century
     data = RTC_read(i2c, Addr_Slave, Century_Month, result);
-    return ((data >> 6) & 0x3);
+    return ((data >> 6) & 0x3) + 20;
 }
 
 unsigned rtc_get_Year(client interface i2c_master_if i2c, i2c_regop_res_t result)


### PR DESCRIPTION
-Fix comment in examples (century: 20-23 instead 21-23)
-fix return value for get_century (return value should be 21 instead of 1)
-fix SQW_FREQ values (change constants from pattern 0xf0 to 0xf)